### PR TITLE
chore: mariadb java.sql.SQLException: Client does not support authent…

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,9 +12,3 @@ spring:
       hibernate:
         format_sql: true
         show_sql: true
-
-  logging:
-    level:
-      org.hibernate:
-        type.descriptor.sql: trace
-        SQL: DEBUG


### PR DESCRIPTION
…ication protocol requested by server. plugin type was = 'sha256_password'

배포하기 위해 오류 해결하기